### PR TITLE
removed broken link to yapc.tv

### DIFF
--- a/views/layouts/main.tt
+++ b/views/layouts/main.tt
@@ -28,7 +28,6 @@
          
         <h3>Other sites</h3>
         <ul>
-          <li><a href="http://yapc.tv/">YAPC.TV</a></li>
           <li><a href="http://www.presentingperl.org/">Presenting Perl</a></li>
           <li><a href="http://videos.missbarbell.co.uk/">2006 and 2007 Perl event videos</a></li>
         </ul>


### PR DESCRIPTION
yapc.tv is not alive. Not sure if you want to link to http://vimeo.com/yapctv instead. Anyways, I removed this for now.
