### PR TITLE
Nova Patch’s profile and talks plus other fixes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,14 +17,15 @@ WriteMakefile(
 		: ()),
 	PL_FILES            => {},
 	PREREQ_PM => {
-		'YAML'           => 0,
-		'Dancer2'        => 0.10,
-		'Path::Tiny'     => 0,
-		'JSON::Tiny'     => 0,
-		'Text::Markdown' => 0,
-		'Plack'          => 0,
-		'Getopt::Long'   => 0,
-		'Pod::Usage'     => 0,
+		'Dancer2'                    => '0.10',
+		'Getopt::Long'               => 0,
+		'JSON::Tiny'                 => '0.41',
+		'Path::Tiny'                 => 0,
+		'Plack'                      => 0,
+		'Pod::Usage'                 => 0,
+		'Text::Markdown'             => 0,
+		'WebService::GData::YouTube' => 0,
+		'YAML::XS'                   => 0,
 
 # for testing
 		'Test::More'     => 0,

--- a/data/people/ingy-dot-net
+++ b/data/people/ingy-dot-net
@@ -1,1 +1,1 @@
-name: Ingy dot Net
+name: Ingy döt Net

--- a/data/people/nick-patch
+++ b/data/people/nick-patch
@@ -1,1 +1,0 @@
-name: Nick Patch

--- a/data/people/nova-patch
+++ b/data/people/nova-patch
@@ -1,0 +1,4 @@
+name: Nova Patch
+nickname: patch
+twitter: novapatch
+home: http://patch.codes/

--- a/data/sources/yapc-na-2015
+++ b/data/sources/yapc-na-2015
@@ -1,0 +1,7 @@
+name: YAPC::NA 2015
+format: markdown
+
+__DESCRIPTION__
+
+[YAPC::NA](http://www.yapcna.org/) is the annual Perl conference in North America.
+In 2015 it was held in [Salt Lake City, Utah](http://www.yapcna.org/yn2015/) between June 8–10.

--- a/data/videos/fundamental-unicode
+++ b/data/videos/fundamental-unicode
@@ -3,11 +3,20 @@ src: youtube
 title: Fundamental Unicode
 speaker: nova-patch
 source: yapc-na-2012
-view_count: 50
-favorite_count: 0
-length: 55:12
+view_count: 73
+favorite_count: 2
+length: 55:11
 date: 2012-06-13
 format: markdown
+abstract: https://speakerdeck.com/patch/fundamental-unicode-in-perl
 
 __DESCRIPTION__
 
+Unicode defines all characters in common use throughout the world and standards
+for parsing, collating, and normalizing textual data. It provides the only
+official encodings for many protocols, languages, and serialization formats
+including JSON, YAML, and XML. Websites, applications, and services have to be
+developed with an understanding of Unicode and can greatly benefit from the
+features it provides. Fortunately, Perl is the premiere language for Unicode
+programming and is rich in functionality. This talk will bring you up to speed
+on Unicode and its encodings and then dive into Perl hacking with Unicode.

--- a/data/videos/fundamental-unicode
+++ b/data/videos/fundamental-unicode
@@ -9,6 +9,7 @@ length: 55:11
 date: 2012-06-13
 format: markdown
 abstract: https://speakerdeck.com/patch/fundamental-unicode-in-perl
+tags: unicode
 
 __DESCRIPTION__
 

--- a/data/videos/fundamental-unicode
+++ b/data/videos/fundamental-unicode
@@ -1,7 +1,7 @@
 id: iaoAXozGGHA
 src: youtube
 title: Fundamental Unicode
-speaker: nick-patch
+speaker: nova-patch
 source: yapc-na-2012
 view_count: 50
 favorite_count: 0

--- a/data/videos/gpw2014-s2e12-removing-the-uppercase-ss-hack-in-unicode---lars-dieckow
+++ b/data/videos/gpw2014-s2e12-removing-the-uppercase-ss-hack-in-unicode---lars-dieckow
@@ -10,6 +10,7 @@ date: 2014-03-27
 format: markdown
 abstract:
 language: de
+tags: unicode
 
 __DESCRIPTION__
 

--- a/data/videos/hello-my-name-is
+++ b/data/videos/hello-my-name-is
@@ -1,0 +1,30 @@
+id: SKbqCB2NPXw
+src: youtube
+title: Hello, my name is __________.
+speaker: nova-patch
+source: yapc-na-2015
+view_count: 159
+favorite_count: 6
+length: 50:26
+date: 2015-06-10
+format: markdown
+abstract: http://patch.codes/talks/hello-my-name-is/
+
+__DESCRIPTION__
+
+Our personal identity is core to how we perceive ourselves and wish to be seen.
+All too often, however, applications, databases, and user interfaces are not
+designed to fully support the diversity of names expressed both locally and
+internationally. This talk demonstrates ways to build applications that respect
+users’ identities instead of limiting them.
+
+Topics include:
+
+ * Input, validation, storage, and display of personal names
+ * Unicode usernames and solutions to security concerns
+ * Internationalization and localization considerations
+
+Although names provide a powerful example and are the focus of this
+presentation, much of the topic is relevant to all types of user input. The
+intended audience includes programmers, UX designers, and QA testers. Together
+we can build inclusive software that supports diverse identities.

--- a/data/videos/hello-my-name-is
+++ b/data/videos/hello-my-name-is
@@ -9,6 +9,7 @@ length: 50:26
 date: 2015-06-10
 format: markdown
 abstract: http://patch.codes/talks/hello-my-name-is/
+tags: unicode
 
 __DESCRIPTION__
 

--- a/data/videos/perl-and-unicode---in-search-of-the-holy-grail
+++ b/data/videos/perl-and-unicode---in-search-of-the-holy-grail
@@ -9,6 +9,7 @@ length: 19:52
 date: 2010-12-04
 format: markdown
 abstract: http://conferences.yapceurope.org/lpw2010/talk/3115
+tags: unicode
 
 __DESCRIPTION__
 

--- a/data/videos/unicode-best-practices
+++ b/data/videos/unicode-best-practices
@@ -3,11 +3,29 @@ src: youtube
 title: Unicode Best Practices
 speaker: nova-patch
 source: yapc-na-2013
-view_count: 1070
-favorite_count: 0
-length: 44:56
-date: 2013-06-03
+view_count: 1172
+favorite_count: 11
+length: 44:55
+date: 2013-06-04
 format: markdown
+abstract: https://speakerdeck.com/patch/unicode-best-practices-in-perl
 
 __DESCRIPTION__
 
+Developing applications to handle the natural languages and written scripts of
+the world—or even a small handful of them—is an impressively large task.
+Fortunately, Unicode provides tools to do just that. It’s more than just a
+character set, it’s a collection of standards for working with the world’s
+textual data. The problem is: Unicode itself is complex!
+
+This talk will help make supporting Unicode easier by providing some of the best
+practices for your projects—whether CPAN modules, RESTful services, or web
+applications. We’ll briefly review Unicode and then dive into best practices for
+handling Unicode text in the following areas:
+
+ * User experience 
+ * Collation (comparison and sorting) 
+ * Input, output, and logging 
+ * Security considerations 
+ * Debugging 
+ * Testing (unit tests and QA)

--- a/data/videos/unicode-best-practices
+++ b/data/videos/unicode-best-practices
@@ -1,7 +1,7 @@
 id: X2FQHUHjo8M
 src: youtube
 title: Unicode Best Practices
-speaker: nick-patch
+speaker: nova-patch
 source: yapc-na-2013
 view_count: 1070
 favorite_count: 0

--- a/data/videos/unicode-best-practices
+++ b/data/videos/unicode-best-practices
@@ -9,6 +9,7 @@ length: 44:55
 date: 2013-06-04
 format: markdown
 abstract: https://speakerdeck.com/patch/unicode-best-practices-in-perl
+tags: unicode
 
 __DESCRIPTION__
 

--- a/data/videos/unicode-beyond-just-characters-localization-with-the-cldr
+++ b/data/videos/unicode-beyond-just-characters-localization-with-the-cldr
@@ -1,7 +1,7 @@
 id: DcPpUnlENAs
 src: youtube
 title: Unicode Beyond Just Characters: Localization with the CLDR
-speaker: nick-patch
+speaker: nova-patch
 source: yapc-na-2014
 view_count: 41
 favorite_count: 0

--- a/data/videos/unicode-beyond-just-characters-localization-with-the-cldr
+++ b/data/videos/unicode-beyond-just-characters-localization-with-the-cldr
@@ -9,6 +9,7 @@ length: 40:42
 date: 2014-06-23
 format: markdown
 abstract: http://patch.codes/talks/localization-with-the-unicode-cldr/
+tags: unicode
 
 __DESCRIPTION__
 

--- a/data/videos/unicode-beyond-just-characters-localization-with-the-cldr
+++ b/data/videos/unicode-beyond-just-characters-localization-with-the-cldr
@@ -1,17 +1,33 @@
 id: DcPpUnlENAs
 src: youtube
-title: Unicode Beyond Just Characters: Localization with the CLDR
+title: Unicode beyond just characters: Localization with the CLDR
 speaker: nova-patch
 source: yapc-na-2014
-view_count: 41
-favorite_count: 0
+view_count: 334
+favorite_count: 4
 length: 40:42
 date: 2014-06-23
 format: markdown
-abstract: http://www.yapcna.org/yn2014/talk/5319
+abstract: http://patch.codes/talks/localization-with-the-unicode-cldr/
 
 __DESCRIPTION__
 
-Unicode is much more than just characters. The Unicode Consortium defines open standards for collating, parsing, and formatting data in much of the world's languages. The Common Locale Data Repository (CLDR) is the largest standard repository of locale data along with specifications for its use and is a powerful resource for software localization. Unicode CLDR is quickly becoming the de facto locale standard with widespread use among companies including Google, Apple, and IBM; projects ranging from Linux distributions to Wikipedia; and increasing support in many programming languages.
+Unicode is much more than just characters. The Unicode Consortium defines open
+standards for collating, parsing, and formatting data in much of the world’s
+languages. The Common Locale Data Repository (CLDR) is the largest standard
+repository of locale data along with specifications for its use, and is a
+powerful resource for software localization.
 
-This talk will provide an introduction to software localization with the CLDR, highlight several CLDR-based CPAN projects, demonstrate how Shutterstock uses and contributes to them, and discuss the remaining work for the Perl community to provide first-class CLDR support.
+The Unicode CLDR is quickly becoming the de facto locale standard with
+widespread use among companies, including Google, Apple, and IBM; projects
+ranging from Linux distributions to Wikipedia; and increasing support in many
+programming languages. This talk provides an introduction to software
+localization and highlights popular CLDR-based open source libraries in a
+variety of programming languages.
+
+Topics include localized formatting of:
+
+ * Numbers, percents, and ranges of numbers
+ * Prices and currencies
+ * Dates and times
+ * Localized sorting lists of strings

--- a/data/videos/unicode-regexes
+++ b/data/videos/unicode-regexes
@@ -8,6 +8,7 @@ favorite_count: 0
 length: 01:55:35
 date: 2012-06-13
 format: markdown
+tags: unicode
 
 __DESCRIPTION__
 

--- a/lib/PerlTV.pm
+++ b/lib/PerlTV.pm
@@ -4,7 +4,7 @@ use Dancer2;
 our $VERSION = '0.01';
 use Cwd qw(abs_path);
 use Path::Tiny ();
-use JSON::Tiny ();
+use JSON::Tiny qw(decode_json);
 use Data::Dumper qw(Dumper);
 use List::Util qw(min);
 use List::MoreUtils qw(uniq);
@@ -14,26 +14,22 @@ use PerlTV::Tools qw(read_file youtube_thumbnail get_atom_xml %languages);
 
 hook before => sub {
 	my $appdir = abs_path config->{appdir};
-	my $json = JSON::Tiny->new;
-	set people => $json->decode( Path::Tiny::path("$appdir/people.json")->slurp_utf8 );
-	set sources => $json->decode( Path::Tiny::path("$appdir/sources.json")->slurp_utf8 );
-	set tags => $json->decode( Path::Tiny::path("$appdir/tags.json")->slurp_utf8 );
-	set modules => $json->decode( Path::Tiny::path("$appdir/modules.json")->slurp_utf8 );
-	my $featured = $json->decode( Path::Tiny::path("$appdir/featured.json")->slurp_utf8 );
+	set people => decode_json( Path::Tiny::path("$appdir/people.json")->slurp_utf8 );
+	set sources => decode_json( Path::Tiny::path("$appdir/sources.json")->slurp_utf8 );
+	set tags => decode_json( Path::Tiny::path("$appdir/tags.json")->slurp_utf8 );
+	set modules => decode_json( Path::Tiny::path("$appdir/modules.json")->slurp_utf8 );
+	my $featured = decode_json( Path::Tiny::path("$appdir/featured.json")->slurp_utf8 );
 	set featured => [ sort {$b->{featured} cmp $a->{featured} }  @$featured ];
-	set not_featured => $json->decode( Path::Tiny::path("$appdir/not_featured.json")->slurp_utf8 );
+	set not_featured => decode_json( Path::Tiny::path("$appdir/not_featured.json")->slurp_utf8 );
 	my $data;
 	eval {
-		$data = $json->decode( Path::Tiny::path("$appdir/videos.json")->slurp_utf8 );
+		$data = decode_json( Path::Tiny::path("$appdir/videos.json")->slurp_utf8 );
 	};
 	if ($@) {
 		set error => 'Could not load videos.json, have you generated it?';
 		warn $@;
 	} elsif (defined $data) {
 		set data => $data;
-	} else {
-		set error => $json->error;
-		warn $json->error;
 	}
 };
 

--- a/lib/PerlTV/Import.pm
+++ b/lib/PerlTV/Import.pm
@@ -4,7 +4,7 @@ use warnings FATAL => 'all';
 use 5.010;
 
 use Path::Tiny qw(path);
-use JSON::Tiny ();
+use JSON::Tiny qw(encode_json);
 use Data::Dumper qw(Dumper);
 
 use PerlTV::Tools qw(read_file youtube_thumbnail);
@@ -12,14 +12,12 @@ use PerlTV::Tools qw(read_file youtube_thumbnail);
 my %sources;
 my %people;
 my %seen;
-my $json;
 my @not_featured;
 my @featured;
 
 
 sub new {
 	my ($class) = @_;
-	$json = JSON::Tiny->new;
 	return bless {}, $class;
 }
 
@@ -31,7 +29,7 @@ sub import_sources {
 		my $source = read_file($f);
 		$sources{ $f->basename } = $source;
 	}
-	path('sources.json')->spew_utf8( $json->encode(\%sources) );
+	path('sources.json')->spew_utf8( encode_json(\%sources) );
 }
 
 
@@ -43,7 +41,7 @@ sub import_people {
 		my $person = read_file($f);
 		$people{ $f->basename } = $person;
 	}
-	path('people.json')->spew_utf8( $json->encode(\%people) );
+	path('people.json')->spew_utf8( encode_json(\%people) );
 }
 
 
@@ -137,12 +135,12 @@ sub import_videos {
 		_comment => 'This is a generated file, please do NOT edit directly',
 		videos => [ sort { $a->{title} cmp $b->{title} } @videos ],
 	);
-	path('videos.json')->spew_utf8( $json->encode(\%data) );
-	path('featured.json')->spew_utf8( $json->encode(\@featured) );
-	path('not_featured.json')->spew_utf8( $json->encode(\@not_featured) );
-	path('tags.json')->spew_utf8( $json->encode(\%tags) );
-	path('modules.json')->spew_utf8( $json->encode(\%modules) );
-	path('public/meta.json')->spew_utf8( $json->encode(\%meta) );
+	path('videos.json')->spew_utf8( encode_json(\%data) );
+	path('featured.json')->spew_utf8( encode_json(\@featured) );
+	path('not_featured.json')->spew_utf8( encode_json(\@not_featured) );
+	path('tags.json')->spew_utf8( encode_json(\%tags) );
+	path('modules.json')->spew_utf8( encode_json(\%modules) );
+	path('public/meta.json')->spew_utf8( encode_json(\%meta) );
 	
 	return \%seen;
 }

--- a/t/002_index_route.t
+++ b/t/002_index_route.t
@@ -2,16 +2,22 @@ use Test::More tests => 6;
 use strict;
 use warnings;
 
-# the order is important
+use Plack::Test;
+use HTTP::Request::Common;
 use PerlTV;
-use Dancer2::Test apps => ['PerlTV'];
 use PerlTV::Tools qw(%languages);
 
 system "$^X bin/import_data.pl";
 
-route_exists [GET => '/'], 'a route handler is defined for /';
-response_status_is ['GET' => '/'], 200, 'response status is 200 for /';
+my $app  = PerlTV->to_app;
+my $test = Plack::Test->create($app);
+
+my $res = $test->request(GET '/');
+ok $res->is_success, 'a route handler is defined for /';
+is $res->code, 200, 'response status is 200 for /';
 
 for my $language_key (keys %languages) {
-	response_status_is ['GET' => '/language/' . $language_key], 200, "response status is 200 for $languages{$language_key}";
+	my $path = '/language/' . $language_key;
+	$res = $test->request(GET $path);
+	is $res->code, 200, "response status is 200 for $path ($languages{$language_key})";
 }


### PR DESCRIPTION
I updated my name, profile, and talks; and performed the following fixes to support modern CPAN module versions.

* JSON::Tiny has removed the OO interface, so I switched to its functions and required v0.41 where they were first introduced
* YAML is replaced with YAML::XS due to Dancer complaining about the former being deprecated in favor of the latter
* WebService::GData::YouTube is required for bin/fetch.pl